### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -2,18 +2,18 @@
 
 *Important update! As of Aug. 5 2013 the master branch was rolled back to work with the latest official OF release. (0.7.4). The master branch will from now on always be kept in sync with the latest official release of OF. Check out the dev branch for a version working with the latest from the develop branch of OF (currently 0.8)*
 
-##About
+## About
 
 ofxShivaVG is a 2d-renderer for openFrameworks based on the ShivaVG OpenVG implementation. It provides improved rendering quality of 2d paths/curves, polylines and shapes, with optional line capping/joining.
 
 Everything is rendered through openGL wich makes it much more performant than other cpu based 2d graphics libraries (Cairo, Quartz etc). It also makes it easy to render 2d and 3d graphics interchangeably.
 
-##Usage
+## Usage
 
 * Clone into openframeworks/addons
 * Add src & lib folders to your project
 
-###Example
+### Example
 
 
 First, you **MUST** enable a stencil buffer in your ofProject. This is done by passing in "stencil" as part of the glut display string. See example below:
@@ -52,7 +52,7 @@ Now all your ofPath's and ofPolylines should look delicious!
 
 See examples for more details.
 
-##Screenshots
+## Screenshots
 
 Default oF renderer:
 
@@ -62,7 +62,7 @@ ofxShivaVGRenderer:
 
 ![Imgur](http://i.imgur.com/hsh4HzM.png)
 
-##Roadmap
+## Roadmap
 
 * Implement arc drawing
 * make ofPath subclass to add cap/join props pr. path


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
